### PR TITLE
Add onRequestError

### DIFF
--- a/src/BinderApi.js
+++ b/src/BinderApi.js
@@ -50,7 +50,14 @@ export default class BinderApi {
 
         Object.assign(axiosOptions, options);
 
-        return axios(axiosOptions).then(this.__responseFormatter);
+        const xhr = axios(axiosOptions);
+
+        // We fork the promise tree as we want to have the error traverse to the listeners
+        if (this.onRequestError) {
+            xhr.catch(this.onRequestError);
+        }
+
+        return xhr.then(this.__responseFormatter);
     }
 
     __responseFormatter(res) {

--- a/src/__tests__/BinderApi.js
+++ b/src/__tests__/BinderApi.js
@@ -116,3 +116,41 @@ test('DELETE request', () => {
 
     return new BinderApi().delete('/api/asdf/');
 });
+
+test('Failing request without onRequestError', () => {
+    const successHandle = jest.fn();
+    const errorHandle = jest.fn();
+
+    mock.onAny().replyOnce(() => {
+        return [500, {}];
+    });
+
+    return new BinderApi()
+        .delete('/api/asdf/')
+        .then(() => successHandle(), () => errorHandle())
+        .then(() => {
+            expect(successHandle).not.toHaveBeenCalled();
+            expect(errorHandle).toHaveBeenCalled();
+        });
+});
+
+test('Failing request with onRequestError', () => {
+    const successHandle = jest.fn();
+    const errorHandle = jest.fn();
+
+    mock.onAny().replyOnce(() => {
+        return [500, {}];
+    });
+
+    const api = new BinderApi();
+    api.onRequestError = jest.fn();
+
+    return new BinderApi()
+        .delete('/api/asdf/')
+        .then(() => successHandle(), () => errorHandle())
+        .then(() => {
+            expect(api.onRequestError).toHaveBeenCalled();
+            expect(successHandle).not.toHaveBeenCalled();
+            expect(errorHandle).toHaveBeenCalled();
+        });
+});

--- a/src/__tests__/BinderApi.js
+++ b/src/__tests__/BinderApi.js
@@ -118,24 +118,6 @@ test('DELETE request', () => {
 });
 
 test('Failing request without onRequestError', () => {
-    const successHandle = jest.fn();
-    const errorHandle = jest.fn();
-
-    mock.onAny().replyOnce(() => {
-        return [500, {}];
-    });
-
-    return new BinderApi()
-        .delete('/api/asdf/')
-        .then(() => successHandle(), () => errorHandle())
-        .then(() => {
-            expect(successHandle).not.toHaveBeenCalled();
-            expect(errorHandle).toHaveBeenCalled();
-        });
-});
-
-test('Failing request with onRequestError', () => {
-    const successHandle = jest.fn();
     const errorHandle = jest.fn();
 
     mock.onAny().replyOnce(() => {
@@ -143,14 +125,28 @@ test('Failing request with onRequestError', () => {
     });
 
     const api = new BinderApi();
+    api.__responseFormatter = jest.fn();
+
+    return api.delete('/api/asdf/').catch(() => errorHandle()).then(() => {
+        expect(api.__responseFormatter).not.toHaveBeenCalled();
+        expect(errorHandle).toHaveBeenCalled();
+    });
+});
+
+test('Failing request with onRequestError', () => {
+    const errorHandle = jest.fn();
+
+    mock.onAny().replyOnce(() => {
+        return [500, {}];
+    });
+
+    const api = new BinderApi();
+    api.__responseFormatter = jest.fn();
     api.onRequestError = jest.fn();
 
-    return new BinderApi()
-        .delete('/api/asdf/')
-        .then(() => successHandle(), () => errorHandle())
-        .then(() => {
-            expect(api.onRequestError).toHaveBeenCalled();
-            expect(successHandle).not.toHaveBeenCalled();
-            expect(errorHandle).toHaveBeenCalled();
-        });
+    return api.delete('/api/asdf/').catch(() => errorHandle()).then(() => {
+        expect(api.onRequestError).toHaveBeenCalled();
+        expect(api.__responseFormatter).not.toHaveBeenCalled();
+        expect(errorHandle).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
Allow an optional function onRequestError to be added to BinderApi.
This function forks the promise of the __request and catches errors on the xhr, which is useful for visual notifications upon API errors in the frontend.

Because of the promise fork then and catch handles will behave the same, this behavior is tested.