### PR TITLE
Fix relation handling of a Store which contains a Model that has a Relation

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -27,6 +27,7 @@ export default class Store {
     Model = null;
     api = null;
     __repository;
+    __nestedRepository = {};
 
     @computed get isLoading() {
         return this.__pendingRequestCount > 0;
@@ -70,9 +71,7 @@ export default class Store {
             records.map(record => {
                 return new this.Model(record, {
                     store: this,
-                    // TODO: fix nested relations in stores.
-                    // This only does not work when using e.g. `owners.location`
-                    // (where `owners` is a store, and `location` a model)
+                    relations: this.__activeRelations,
                 });
             })
         );

--- a/src/__tests__/Model.js
+++ b/src/__tests__/Model.js
@@ -267,7 +267,7 @@ test('Parsing two times with store relation', () => {
     expect(animal.pastOwners.map('id')).toEqual([3]);
 });
 
-xtest('Parsing store relation with model relation in it', () => {
+test('Parsing store relation with model relation in it', () => {
     const animal = new Animal(null, {
         relations: ['pastOwners.town'],
     });
@@ -281,10 +281,12 @@ xtest('Parsing store relation with model relation in it', () => {
         relMapping: animalsWithPastOwnersAndTownData.with_mapping,
     });
 
-    expect(animal.pastOwners.map('id')).toBe([55, 66]);
+    expect(animal.pastOwners.map('id')).toEqual([55, 66]);
     expect(animal.pastOwners.get(55).town).toBeInstanceOf(Location);
-    expect(animal.pastOwners.get(55).town.id).toBe(11);
+    expect(animal.pastOwners.get(55).town.id).toBe(10);
+    expect(animal.pastOwners.get(55).town.name).toBe('Eindhoven');
     expect(animal.pastOwners.get(66).town.id).toBe(11);
+    expect(animal.pastOwners.get(66).town.name).toBe('Breda');
 });
 
 test('toBackend with basic properties', () => {


### PR DESCRIPTION
The code has to be reviewed, but at least the tests work.
The code to set the nestedRepository of the Store  doesn't belong in the model.
Also fetching setting the correct NestedRepository from the parent Store doesn't belong in the Model.

I would like to see the model fromBackend, if it has a store in its relation chain, pass through the fromBackend of that store. This way we can handle the store logic in the store.
This however requires quite a big rewrite of mobx-spine so I'm leaving that to @SpaceK33z 
