### PR TITLE
Refactor fromBackend to be recursive

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -9,6 +9,7 @@ import {
     toJS,
 } from 'mobx';
 import {
+    each,
     forIn,
     mapValues,
     find,
@@ -285,60 +286,139 @@ export default class Model {
         this.__fetchParams = Object.assign({}, params);
     }
 
+    /**
+     * We handle the fromBackend recursively.
+     * But when recursing, we don't send the full repository, we need to only send the part
+     * relevant to the relation.
+     *
+     * So when we have a customer with a town.restaurants relation,
+     * and we want to recurse, we only send { restaurants: [...] } to the town relation
+     * And send the stuff in the town: relation as data
+     */
+    __scopeBackendResponse(data, targetRelName, repos, mapping) {
+        let scopedData = null;
+        let relevant = false;
+        const scopedRepos = {};
+        const scopedRelMapping = {};
+
+        forIn(mapping, (repoName, relName) => {
+            const repository = repos[repoName];
+            relName = this.fromBackendAttrKey(relName);
+
+            // NOTE:
+            // we want to give the data to the relation,
+            // however model relations want {} and store relations want []
+            if (targetRelName === relName) {
+                relevant = true;
+                const relFk = data[relName];
+
+                if (isArray(relFk)) {
+                    scopedData = repository;
+                } else {
+                    scopedData = find(repository, { id: relFk });
+                }
+                return;
+            }
+
+            if (relName.startsWith(targetRelName)) {
+                // If we have town.restaurants and the targetRel = town
+                // we need "restaurants" in the repository
+                relevant = true;
+                const relNames = relName.match(/([^.]+)\.(.+)/);
+                const scopedRelName = relNames[2];
+                scopedRepos[repoName] = repository;
+                scopedRelMapping[scopedRelName] = repoName;
+            }
+        });
+
+        if (!relevant) {
+            return false;
+        }
+
+        return { scopedData, scopedRepos, scopedRelMapping };
+    }
+
     @action fromBackend({ data, repos, relMapping }) {
+        // We handle the fromBackend recursively,
+        // so when we have `town.restaurants.chef`
+        // we only need `town`
+        // That's why we use __activeCurrentRelations instead of __activeRelations
+        each(this.__activeCurrentRelations, relName => {
+            const rel = this[relName];
+            const resScoped = this.__scopeBackendResponse(
+                data,
+                relName,
+                repos,
+                relMapping
+            );
+
+            // Make sure we don't parse every relation for nothing
+            if (!resScoped) {
+                return;
+            }
+            const { scopedData, scopedRepos, scopedRelMapping } = resScoped;
+            rel.fromBackend({
+                data: scopedData,
+                repos: scopedRepos,
+                relMapping: scopedRelMapping,
+            });
+        });
         // `data` contains properties for the current model.
         // `repos` is an object of "repositories". A repository is
         // e.g. "animal_kind", while the relation name would be "kind".
         // `relMapping` maps relation names to repositories.
-        forIn(relMapping, (repoName, relName) => {
-            const repository = repos[repoName];
-            // All nested models get a repository. At this time we don't know yet
-            // what id the model should get, since the parent may or may not be set.
-            let model = get(this, this.fromBackendAttrKey(relName));
+        // forIn(relMapping, (repoName, relName) => {
+        //     const repository = repos[repoName];
+        //     // All nested models get a repository. At this time we don't know yet
+        //     // what id the model should get, since the parent may or may not be set.
+        //     let model = get(this, this.fromBackendAttrKey(relName));
 
-            // If we have a model which has a store relation which has a nested relation,
-            // the model doesn't exist yet
-            if (model === undefined) {
-                // We need to find the first store in the chain
-                // But we currently only support Model > Store > Model
-                // If there are more Models/Store in the length the "find first store in chain"
-                // needs to be implemented
-                const rels = relName.split('.');
-                let store;
-                let nestedRel;
+        //     if (model) {
+        //     }
 
-                // Find the first Store relation in the relation chain
-                rels.some((rel, i) => {
-                    // Try rel, rel.rel, rel.rel.rel, etc.
-                    const subRelName = rels.slice(0, i + 1).join('.');
-                    const subRel = get(
-                        this,
-                        this.fromBackendAttrKey(subRelName)
-                    );
+        //     // If we have a model which has a store relation which has a nested relation,
+        //     // the model doesn't exist yet
+        //     if (model === undefined) {
+        //         // We need to find the first store in the chain
+        //         // But we currently only support Model > Store > Model
+        //         // If there are more Models/Store in the length the "find first store in chain"
+        //         // needs to be implemented
+        //         const rels = relName.split('.');
+        //         let store;
+        //         let nestedRel;
 
-                    if (subRel instanceof Store) {
-                        store = subRel;
-                        // Now we found the store.
-                        // The store has models, and those models have another (model) relation.
-                        //
-                        // We need to set the a `__nestedRepository` in the store
-                        // That means that when models get added to the store,
-                        // Their relation is filled from the correct `__nestedRepository` in the store.
-                        //
-                        // So a Dog has PastOwners (store), the Owners in that store have a Town rel.
-                        // We set 'town': repository in the `__nestedRepository` of the PastOwners
-                        // When Owners get added, parsed, whatever, their town relation is set,
-                        // using `Store.__nestedRepository`.
-                        nestedRel = rels.slice(i + 1, rels.length).join('.');
-                        return true;
-                    }
-                    return false;
-                });
-                store.__nestedRepository[nestedRel] = repository;
-            } else {
-                model.__repository = repository;
-            }
-        });
+        //         // Find the first Store relation in the relation chain
+        //         rels.some((rel, i) => {
+        //             // Try rel, rel.rel, rel.rel.rel, etc.
+        //             const subRelName = rels.slice(0, i + 1).join('.');
+        //             const subRel = get(
+        //                 this,
+        //                 this.fromBackendAttrKey(subRelName)
+        //             );
+
+        //             if (subRel instanceof Store) {
+        //                 store = subRel;
+        //                 // Now we found the store.
+        //                 // The store has models, and those models have another (model) relation.
+        //                 //
+        //                 // We need to set the a `__nestedRepository` in the store
+        //                 // That means that when models get added to the store,
+        //                 // Their relation is filled from the correct `__nestedRepository` in the store.
+        //                 //
+        //                 // So a Dog has PastOwners (store), the Owners in that store have a Town rel.
+        //                 // We set 'town': repository in the `__nestedRepository` of the PastOwners
+        //                 // When Owners get added, parsed, whatever, their town relation is set,
+        //                 // using `Store.__nestedRepository`.
+        //                 nestedRel = rels.slice(i + 1, rels.length).join('.');
+        //                 return true;
+        //             }
+        //             return false;
+        //         });
+        //         store.__nestedRepository[nestedRel] = repository;
+        //     } else {
+        //         model.__repository = repository;
+        //     }
+        // });
 
         // Now all repositories are set on the relations, start parsing the actual data.
         // `parse()` will recursively fill in all relations.
@@ -359,12 +439,12 @@ export default class Model {
         return this.api;
     }
 
-    __addFromRepository(id) {
-        const relData = find(this.__repository, { id });
-        if (relData) {
-            this.parse(relData);
-        }
-    }
+    // __addFromRepository(id) {
+    //     const relData = find(this.__repository, { id });
+    //     if (relData) {
+    //         this.parse(relData);
+    //     }
+    // }
 
     @action parse(data) {
         invariant(
@@ -381,7 +461,7 @@ export default class Model {
                 if (isPlainObject(value) || isPlainObject(get(value, '[0]'))) {
                     this[attr].parse(value);
                 } else {
-                    this[attr].__addFromRepository(value);
+                    // this[attr].__addFromRepository(value);
                 }
             }
         });

--- a/src/Model.js
+++ b/src/Model.js
@@ -166,11 +166,6 @@ export default class Model {
                     `Specified relation "${relName}" does not exist on model.`
                 );
                 const options = { relations: otherRelNames };
-                if (this.__store && this.__store.__nestedRepository[relName]) {
-                    options.repository = this.__store.__nestedRepository[
-                        relName
-                    ];
-                }
                 if (RelModel.prototype instanceof Store) {
                     return new RelModel(options);
                 }

--- a/src/Store.js
+++ b/src/Store.js
@@ -4,10 +4,8 @@ import {
     map,
     filter,
     find,
-    keyBy,
     sortBy,
     forIn,
-    at,
     isPlainObject,
     result,
 } from 'lodash';
@@ -35,7 +33,6 @@ export default class Store {
     Model = null;
     api = null;
     __repository;
-    __nestedRepository = {};
     static backendResourceName = '';
 
     @computed get isLoading() {

--- a/src/Store.js
+++ b/src/Store.js
@@ -84,24 +84,6 @@ export default class Store {
         this.__activeRelations = activeRelations;
     }
 
-    @action __addFromRepository(ids = []) {
-        ids = isArray(ids) ? ids : [ids];
-
-        const records = at(
-            keyBy(this.__repository, this.Model.primaryKey),
-            ids
-        );
-        this.models.replace(
-            records.map(record => {
-                return new this.Model(record, {
-                    store: this,
-                    relations: this.__activeRelations,
-                });
-            })
-        );
-        this.sort();
-    }
-
     __getApi() {
         invariant(
             this.api,

--- a/src/__tests__/Model.js
+++ b/src/__tests__/Model.js
@@ -223,7 +223,7 @@ test('Non existent relation should throw an error', () => {
     }).toThrow('Specified relation "ponyfoo" does not exist on model.');
 });
 
-test('Parsing two-level relation', () => {
+test('Parsing two-level relation (with repos)', () => {
     const animal = new Animal(null, {
         relations: ['kind.breed'],
     });


### PR DESCRIPTION
In this pull request we make `fromBackend` recursive and `parse` non recursive.

With this change, fromBackend also gets called on the relations and every relation handles its own relation parsing, getting rid of the `__nestedRepository` and fixing #37 

When recursively calling `fromBackend, the `data`, `repository` and `relMapping` are scoped to the relation.

