### PR TITLE
Allow requestOptions on a delete

### DIFF
--- a/src/BinderApi.js
+++ b/src/BinderApi.js
@@ -56,10 +56,9 @@ export default class BinderApi {
             xhr.catch(this.onRequestError);
         }
 
-        const onSuccess =
-            options.skipFormatter === true
-                ? Promise.resolve()
-                : this.__responseFormatter;
+        const onSuccess = options.skipFormatter === true
+            ? Promise.resolve()
+            : this.__responseFormatter;
         return xhr.then(onSuccess);
     }
 
@@ -161,9 +160,9 @@ export default class BinderApi {
             });
     }
 
-    deleteModel({ url, params }) {
+    deleteModel({ url, requestOptions }) {
         // TODO: kind of silly now, but we'll probably want better error handling soon.
-        return this.delete(url, null, { params });
+        return this.delete(url, null, requestOptions);
     }
 
     buildFetchStoreParams(store) {

--- a/src/Model.js
+++ b/src/Model.js
@@ -663,7 +663,7 @@ export default class Model {
         return this.__getApi()
             .deleteModel({
                 url: options.url || this.url,
-                params: options.params,
+                requestOptions: omit(options, ['immediate', 'url']),
             })
             .then(
                 action(() => {

--- a/src/__tests__/Model.js
+++ b/src/__tests__/Model.js
@@ -1183,6 +1183,27 @@ describe('requests', () => {
         return animal.delete({ params: { branch_id: 1 } });
     });
 
+    test('delete with requestOptions', () => {
+        const animal = new Animal({ id: 1 });
+        const spy = jest.spyOn(animal.api, 'delete');
+        const requestOptions = {
+            params: { branch_id: 1 },
+            skipRequestErrors: true,
+        };
+
+        mock.onAny().replyOnce(config => {
+            return [204, null];
+        });
+
+        animal.delete(requestOptions);
+
+        expect(spy).toHaveBeenCalledWith(
+            '/api/animal/1/',
+            null,
+            requestOptions
+        );
+    });
+
     test('isLoading', () => {
         const animal = new Animal({ id: 2 });
         expect(animal.isLoading).toBe(false);


### PR DESCRIPTION
Currently only `params` of the options of `Model.delete` get passed to the `__request`, making it impossible to call a delete with requestOptions like `skipRequestError`.

This change passes all the options of the `delete` (except for `url` and `immediate`) to `__request`