### PR TITLE
Add fix for initializing unbalanced relations.

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -167,12 +167,18 @@ export default class Model {
         const relations = this.relations && this.relations();
         const relModels = {};
         activeRelations.forEach(aRel => {
+            // If aRel is null, this relation is already defined by another aRel
+            // IE.: town.restaurants.chef && town
+            if (aRel === null) {
+                return;
+            }
             const relNames = aRel.match(RE_SPLIT_FIRST_RELATION);
 
             const currentRel = relNames ? relNames[1] : aRel;
             const otherRelNames = relNames && relNames[2];
             const currentProp = relModels[currentRel];
             const otherRels = otherRelNames && [otherRelNames];
+
             // When two nested relations are defined next to each other (e.g. `['kind.breed', 'kind.location']`),
             // the relation `kind` only needs to be initialized once.
             relModels[currentRel] = currentProp

--- a/src/__tests__/fixtures/customers-with-town-restaurants-unbalanced.json
+++ b/src/__tests__/fixtures/customers-with-town-restaurants-unbalanced.json
@@ -1,0 +1,61 @@
+{
+  "data": [
+    {
+        "id": 1,
+        "name": "Henk",
+        "town": 1
+    },
+    {
+        "id": 2,
+        "name": "Karel",
+        "town": 2
+    }
+  ],
+  "with": {
+    "town": [
+      {
+        "id": 1,
+        "name": "Hardinxveld",
+        "restaurants": [
+          1,
+          2
+        ]
+      },
+      {
+        "id": 2,
+        "name": "Meerkerk",
+        "restaurants": []
+      }
+    ],
+    "restaurant": [
+      {
+        "id": 1,
+        "name": "Fastfood",
+        "chef": 1
+      },
+      {
+        "id": 2,
+        "name": "Seafood",
+        "chef": 2
+      }
+    ],
+    "cook": [
+      {
+        "id": 1,
+        "name": "Snor"
+      },
+      {
+        "id": 2,
+        "name": "Baard"
+      }
+    ]
+  },
+  "meta": {
+    "total_records": 1
+  },
+  "with_mapping": {
+    "town": "town",
+    "town.restaurants": "restaurant",
+    "town.restaurants.chef": "cook"
+  }
+}


### PR DESCRIPTION
When instantiating unbalanced relations like this:
`relations: ['town.restaurants.chef', 'town'],`
mobx-spine throws an error:
`Uncaught (in promise) TypeError: Cannot read property 'match' of null`

Now only supplying `town.restaurants.chef` would be enough, but i don't think it should throw such an unspecific error when encountering this edgecase.

I encountered this bug when automatically generating the relationset based on the treestructure of a nested backend response. Detecting subsets is a difficult problem to solve efficiently.