### PR TITLE
Add good error description if M2M is not set correctly in backend

### DIFF
--- a/dist/mobx-spine.cjs.js
+++ b/dist/mobx-spine.cjs.js
@@ -275,6 +275,10 @@ var Store = ((_class$1 = ((_temp$1 = _class2$1 = (function() {
                     repos = _ref.repos,
                     relMapping = _ref.relMapping;
 
+                if (data === undefined) {
+                    throw 'Backend error. Data is not set. HINT: DID YOU FORGET THE M2M again?';
+                }
+
                 this.models.replace(
                     data.map(function(record) {
                         // TODO: I'm not happy at all about how this looks.

--- a/dist/mobx-spine.cjs.js
+++ b/dist/mobx-spine.cjs.js
@@ -275,9 +275,10 @@ var Store = ((_class$1 = ((_temp$1 = _class2$1 = (function() {
                     repos = _ref.repos,
                     relMapping = _ref.relMapping;
 
-                if (data === undefined) {
-                    throw 'Backend error. Data is not set. HINT: DID YOU FORGET THE M2M again?';
-                }
+                invariant(
+                    data,
+                    'Backend error. Data is not set. HINT: DID YOU FORGET THE M2M again?'
+                );
 
                 this.models.replace(
                     data.map(function(record) {

--- a/dist/mobx-spine.es.js
+++ b/dist/mobx-spine.es.js
@@ -294,9 +294,10 @@ var Store = ((_class$1 = ((_temp$1 = _class2$1 = (function() {
                     repos = _ref.repos,
                     relMapping = _ref.relMapping;
 
-                if (data === undefined) {
-                    throw 'Backend error. Data is not set. HINT: DID YOU FORGET THE M2M again?';
-                }
+                invariant(
+                    data,
+                    'Backend error. Data is not set. HINT: DID YOU FORGET THE M2M again?'
+                );
 
                 this.models.replace(
                     data.map(function(record) {

--- a/dist/mobx-spine.es.js
+++ b/dist/mobx-spine.es.js
@@ -294,6 +294,10 @@ var Store = ((_class$1 = ((_temp$1 = _class2$1 = (function() {
                     repos = _ref.repos,
                     relMapping = _ref.relMapping;
 
+                if (data === undefined) {
+                    throw 'Backend error. Data is not set. HINT: DID YOU FORGET THE M2M again?';
+                }
+
                 this.models.replace(
                     data.map(function(record) {
                         // TODO: I'm not happy at all about how this looks.

--- a/src/Store.js
+++ b/src/Store.js
@@ -109,6 +109,10 @@ export default class Store {
 
     @action
     fromBackend({ data, repos, relMapping }) {
+        if (data === undefined) {
+            throw 'Backend error. Data is not set. HINT: DID YOU FORGET THE M2M again?';
+        }
+
         this.models.replace(
             data.map(record => {
                 // TODO: I'm not happy at all about how this looks.

--- a/src/Store.js
+++ b/src/Store.js
@@ -109,9 +109,10 @@ export default class Store {
 
     @action
     fromBackend({ data, repos, relMapping }) {
-        if (data === undefined) {
-            throw 'Backend error. Data is not set. HINT: DID YOU FORGET THE M2M again?';
-        }
+        invariant(
+            data,
+            'Backend error. Data is not set. HINT: DID YOU FORGET THE M2M again?'
+        );
 
         this.models.replace(
             data.map(record => {


### PR DESCRIPTION
As we know, many of us have spend many hours debugging a very vague error, only to realize that a M2M field is not set correctly in the backend. This fixes it. it checks if the data is not returned by the backend, and then gives an exception that something is wrong, and gives the hint that the M2M field is forgotten:

![image](https://user-images.githubusercontent.com/7164637/36591743-3d44c4ec-1893-11e8-952c-772cff123616.png)
