### PR TITLE
Move validation of error formatter to a seperate function

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -634,12 +634,13 @@ export default class Model {
         });
     }
 
-    validationErrorFormatter = obj => obj.code;
+    validationErrorFormatter(obj) {
+        return obj.code;
+    }
 
     @action
     parseValidationErrors(valErrors) {
         const bname = this.constructor.backendResourceName;
-
         if (valErrors[bname]) {
             const id = this.getInternalId();
             // When there is no id or negative id, the backend may use the string 'null'. Bit weird, but eh.

--- a/src/Model.js
+++ b/src/Model.js
@@ -641,6 +641,7 @@ export default class Model {
     @action
     parseValidationErrors(valErrors) {
         const bname = this.constructor.backendResourceName;
+
         if (valErrors[bname]) {
             const id = this.getInternalId();
             // When there is no id or negative id, the backend may use the string 'null'. Bit weird, but eh.

--- a/src/Model.js
+++ b/src/Model.js
@@ -634,6 +634,8 @@ export default class Model {
         });
     }
 
+    validationErrorFormatter = obj => obj.code;
+
     @action
     parseValidationErrors(valErrors) {
         const bname = this.constructor.backendResourceName;
@@ -650,7 +652,7 @@ export default class Model {
                 const formattedErrors = mapValues(
                     camelCasedErrors,
                     valError => {
-                        return valError.map(obj => obj.code);
+                        return valError.map(this.validationErrorFormatter);
                     }
                 );
                 this.__backendValidationErrors = formattedErrors;

--- a/src/__tests__/Model.js
+++ b/src/__tests__/Model.js
@@ -777,6 +777,27 @@ test('setInput to clear backend validation errors', () => {
     expect(animal.backendValidationErrors.name).toBe(undefined);
 });
 
+test('allow custom validationErrorFormatter', () => {
+    const location = new class extends Location {
+        static backendResourceName = 'location';
+        validationErrorFormatter(obj) {
+            return obj.msg;
+        }
+    }({ id: 2 });
+
+    location.parseValidationErrors({
+        location: {
+            2: {
+                name: [{ msg: 'Error 1' }, { msg: 'Error 2' }],
+            },
+        },
+    });
+
+    expect(toJS(location.backendValidationErrors)).toEqual({
+        name: ['Error 1', 'Error 2'],
+    });
+});
+
 test('setInput on non-existing field', () => {
     const animal = new Animal();
     expect(() => {


### PR DESCRIPTION
This PR is very simple, it moves the formatter for the validation error to a seperate function. No BC breakage.

**Use case**: 
Binder returns messages clearly describing the error that has occured. We can not access them now, because we only display the code. 

Old case:
To show the messages the whole `parseValidationErrors` needs to be overridden

New case:
You can override the `validationErrorFormatter` like this:
```
validationErrorFormatter = obj => obj.message
```