### PR TITLE
Automatically convert files in data to the format understood by django binder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['6']
+        node-version: ['14']
 
     steps:
       - name: Checkout code

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "moment": "^2.22.0"
   },
   "jest": {
-    "testEnvironment": "node",
+    "testEnvironment": "jsdom",
     "roots": [
       "./src"
     ],

--- a/src/Model.js
+++ b/src/Model.js
@@ -14,7 +14,6 @@ import {
     mapValues,
     find,
     filter,
-    get,
     isPlainObject,
     isArray,
     omit,
@@ -23,7 +22,6 @@ import {
     uniqBy,
     mapKeys,
     result,
-    pick,
 } from 'lodash';
 import Store from './Store';
 import { invariant, snakeToCamel, camelToSnake, relationsToNestedKeys, forNestedRelations } from './utils';

--- a/src/__tests__/Model.js
+++ b/src/__tests__/Model.js
@@ -518,9 +518,6 @@ test('toBackend with omit fields', () => {
 
     const serialized = model.toBackend();
 
-    const expected = {
-        weight: 32
-    }
     expect(serialized).toEqual({
         color: 'red',
         id: 1

--- a/src/__tests__/Model.js
+++ b/src/__tests__/Model.js
@@ -1046,23 +1046,23 @@ describe('requests', () => {
                 data_file: null,
                 id: 5,
             });
-            return [200, { data: { id: 5, data_file: dataFile } }];
+            return [200, { id: 5, data_file: '/api/dataFile' } ];
         });
 
-        file.save().then(() => {
+        file.save().then(res => {
             expect(file.id).toBe(5);
-            expect(file.dataFile).toBeInstanceOf(Blob);
+            expect(file.dataFile).toBe('/api/dataFile');
         });
     });
 
-    test('Save model with realtion and multiple files', () => {
+    test('Save model with relations and multiple files', () => {
         const fileCabinet = new FileCabinet({ id: 5 },{relations: ['files']});
-        const dataFile1 = new Blob(['foo'], { type: 'text/plain' });
-        fileCabinet.files.add({ dataFile: dataFile1 });
-        const dataFile2 = new Blob(['bar'], { type: 'text/plain' });
-        fileCabinet.files.add({ dataFile: dataFile2 });
-        const dataFile3 = new Blob(['baz'], { type: 'text/plain' });
-        fileCabinet.files.add({ dataFile: dataFile3 });
+        fileCabinet.files.add([
+            { dataFile: new Blob(['bar'], { type: 'text/plain' }) },
+            { dataFile: new Blob(['foo'], { type: 'text/plain' }) },
+            { dataFile: new Blob(['baz'], { type: 'text/plain' }) },
+        ]);
+
 
         mock.onAny().replyOnce(config => {
             expect(config.method).toBe('put');

--- a/src/__tests__/Model.js
+++ b/src/__tests__/Model.js
@@ -1049,7 +1049,7 @@ describe('requests', () => {
             return [200, { id: 5, data_file: '/api/dataFile' } ];
         });
 
-        file.save().then(res => {
+        file.save().then(() => {
             expect(file.id).toBe(5);
             expect(file.dataFile).toBe('/api/dataFile');
         });
@@ -1062,7 +1062,6 @@ describe('requests', () => {
             { dataFile: new Blob(['foo'], { type: 'text/plain' }) },
             { dataFile: new Blob(['baz'], { type: 'text/plain' }) },
         ]);
-
 
         mock.onAny().replyOnce(config => {
             expect(config.method).toBe('put');

--- a/src/__tests__/fixtures/Animal.js
+++ b/src/__tests__/fixtures/Animal.js
@@ -7,6 +7,32 @@ export class Location extends Model {
     @observable name = '';
 }
 
+export class File extends Model {
+    urlRoot = '/api/file/';
+    api = new BinderApi();
+    static backendResourceName = 'file';
+    @observable id = null;
+    @observable dataFile = null;
+}
+
+export class FileStore extends Store {
+    Model = File
+}
+
+export class FileCabinet extends Model {
+    urlRoot = '/api/file_cabinet/';
+    api = new BinderApi();
+    static backendResourceName = 'file_cabinet';
+    @observable id = null;
+
+    relations() {
+        return {
+            files: FileStore,
+        }
+    }
+}
+
+
 export class Breed extends Model {
     @observable id = null;
     @observable name = '';


### PR DESCRIPTION
Support to automatically use the body format implemented in https://github.com/CodeYellowBV/django-binder/pull/168 to support sending files together with deeply nested data.