### PR TITLE
Parse empty list bug

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -594,7 +594,7 @@ export default class Model {
                 // However, it can also be an object if there are nested relations (non flattened).
                 if (isPlainObject(value) || isPlainObject(get(value, '[0]'))) {
                     this[attr].parse(value);
-                } else if (value === null) {
+                } else {
                     // The relation is cleared.
                     this[attr].clear();
                 }

--- a/src/Model.js
+++ b/src/Model.js
@@ -592,9 +592,9 @@ export default class Model {
             } else if (this.__activeCurrentRelations.includes(attr)) {
                 // In Binder, a relation property is an `int` or `[int]`, referring to its ID.
                 // However, it can also be an object if there are nested relations (non flattened).
-                if (isPlainObject(value) || isPlainObject(get(value, '[0]'))) {
+                if (isPlainObject(value) || (Array.isArray(value) && value.every(isPlainObject))) {
                     this[attr].parse(value);
-                } else {
+                } else if (value === null) {
                     // The relation is cleared.
                     this[attr].clear();
                 }

--- a/src/__tests__/Model.js
+++ b/src/__tests__/Model.js
@@ -990,6 +990,16 @@ test('setInput to parse store relation', () => {
     expect(animal.pastOwners.length).toBe(0);
 });
 
+test('parse empty list', () => {
+    const animal = new Animal(
+        { pastOwners: [{}, {}] },
+        { relations: ['pastOwners'] },
+    );
+    expect(animal.pastOwners.length).toEqual(2);
+    animal.parse({ pastOwners: [] });
+    expect(animal.pastOwners.length).toEqual(0);
+});
+
 describe('requests', () => {
     let mock;
     beforeEach(() => {


### PR DESCRIPTION
When an empty list is sent in the data in `Model.parse` it used to be ignored. This can cause bugs because old data remains around. I changed the check for when to parse a list from 'a list where the first element is a plain object' to 'a list where every element is a plain object'. This actually makes the check more correct for lists with multiple base cases and the base case for every makes sure it also works for the empty list.