### PR TITLE
Unify save & save all

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ The `save` function accepts a few paramaters as an `options` object:
 |data|undefined|When set, append `data` to result. Existing keys from `toBackend` will be overwritten by data, while new keys will be added. | `animal.save({ data: { id: 1, some_other_field: 'will be added' } })`
 |mapData|undefined|You can change the data which will be used for the request send by supplying a function. First argument is the formatted data ready for sending a request. Called at the very last of data formatting operations.| `animal.save({ mapData: data => (...data, some_other_field: 'will be added' } ) } })`
 |forceFields|undefined|When `onlyChanges` is given, you can force fields to be included despite of having no changes.| `animal.save({ onlyChanges: true, forceFields: ['name'] } ) } })`
-|relations|undefined|Relations to be instantiated when instantiating this model as well. Should be an array of strings.| `animal = new Animal({ relations: ['location', 'owner.parents'] })`
+|relations|undefined|Relations to save when saving this model as well. Note that its not needed to include relations here so that they will be linked, only to save the models themselves. Should be an array of strings.| `animal.save({ relations: ['location', 'owner.parents'] })`
 
 #### Backend request: delete
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -726,11 +726,6 @@ export default class Model {
         }
     }
 
-    saveAll(options) {
-        console.warn('Calling Model.saveAll directly is deprecated, call Model.save with relations instead');
-        return this._saveAll(options);
-    }
-
     @action
     _save(options = {}) {
         this.clearValidationErrors();

--- a/src/Model.js
+++ b/src/Model.js
@@ -663,44 +663,6 @@ export default class Model {
     }
 
     @action
-    save(options = {}) {
-        this.clearValidationErrors();
-        return this.wrapPendingRequestCount(
-            this.__getApi()
-            .saveModel({
-                url: options.url || this.url,
-                data: this.toBackend({
-                        data: options.data,
-                        mapData: options.mapData,
-                        fields: options.fields,
-                        onlyChanges: options.onlyChanges,
-                    }),
-                isNew: this.isNew,
-                requestOptions: omit(options, 'url', 'data', 'mapData')
-            })
-            .then(action(res => {
-                this.saveFromBackend({
-                    ...res,
-                    data: omit(res.data, this.fileFields().map(camelToSnake)),
-                });
-                this.clearUserFieldChanges();
-                return this.saveFiles().then(() => {
-                    this.clearUserFileChanges();
-                    return Promise.resolve(res);
-                });
-            }))
-            .catch(
-                action(err => {
-                    if (err.valErrors) {
-                        this.parseValidationErrors(err.valErrors);
-                    }
-                    throw err;
-                })
-            )
-        );
-    }
-
-    @action
     setInput(name, value) {
         invariant(
             this.__attributes.includes(name) ||
@@ -756,8 +718,59 @@ export default class Model {
         return Promise.all(promises);
     }
 
+    save(options = {}) {
+        if (options.relations && options.relations.length > 0) {
+            return this._saveAll(options);
+        } else {
+            return this._save(options);
+        }
+    }
+
+    saveAll(options) {
+        console.warn('Calling Model.saveAll directly is deprecated, call Model.save with relations instead');
+        return this._saveAll(options);
+    }
+
     @action
-    saveAll(options = {}) {
+    _save(options = {}) {
+        this.clearValidationErrors();
+        return this.wrapPendingRequestCount(
+            this.__getApi()
+            .saveModel({
+                url: options.url || this.url,
+                data: this.toBackend({
+                        data: options.data,
+                        mapData: options.mapData,
+                        fields: options.fields,
+                        onlyChanges: options.onlyChanges,
+                    }),
+                isNew: this.isNew,
+                requestOptions: omit(options, 'url', 'data', 'mapData')
+            })
+            .then(action(res => {
+                this.saveFromBackend({
+                    ...res,
+                    data: omit(res.data, this.fileFields().map(camelToSnake)),
+                });
+                this.clearUserFieldChanges();
+                return this.saveFiles().then(() => {
+                    this.clearUserFileChanges();
+                    return Promise.resolve(res);
+                });
+            }))
+            .catch(
+                action(err => {
+                    if (err.valErrors) {
+                        this.parseValidationErrors(err.valErrors);
+                    }
+                    throw err;
+                })
+            )
+        );
+    }
+
+    @action
+    _saveAll(options = {}) {
         this.clearValidationErrors();
         return this.wrapPendingRequestCount(
             this.__getApi()

--- a/src/__tests__/Model.js
+++ b/src/__tests__/Model.js
@@ -1240,6 +1240,7 @@ describe('requests', () => {
         return animal.save({ data: { extra_data: 'can be saved' }, mapData: data => ({ ...data, id: 'overwritten' }) });
     });
 
+    // OLD
     test('save all with relations', () => {
         const animal = new Animal(
             {
@@ -1617,6 +1618,207 @@ describe('requests', () => {
         return animal.saveAll().then(() => {
             expect(animal.pastOwners.hasUserChanges).toBe(true);
             expect(animal.hasUserChanges).toBe(true);
+        });
+    });
+
+    // NEW
+    test('save all with relations', () => {
+        const animal = new Animal(
+            {
+                name: 'Doggo',
+                kind: { name: 'Dog' },
+                pastOwners: [{ name: 'Henk' }],
+            },
+            { relations: ['kind', 'pastOwners'] }
+        );
+        const spy = jest.spyOn(animal, 'saveFromBackend');
+        mock.onAny().replyOnce(config => {
+            expect(config.url).toBe('/api/animal/');
+            expect(config.method).toBe('put');
+            return [201, animalMultiPutResponse];
+        });
+
+        return animal.save({ relations: ['kind'] }).then(response => {
+            expect(spy).toHaveBeenCalled();
+            expect(animal.id).toBe(10);
+            expect(animal.kind.id).toBe(4);
+            expect(animal.pastOwners.at(0).id).toBe(100);
+            expect(response).toEqual(animalMultiPutResponse);
+
+            spy.mockReset();
+            spy.mockRestore();
+        });
+    });
+
+    test('save all with relations - verify ids are mapped correctly', () => {
+        const animal = new Animal(
+            {
+                pastOwners: [{ name: 'Henk' }, { id: 125, name: 'Hanos' }],
+            },
+            { relations: ['pastOwners'] }
+        );
+        // Sanity check unrelated to the actual test.
+        expect(animal.pastOwners.at(0).getInternalId()).toBe(-2);
+
+        mock.onAny().replyOnce(config => {
+            return [
+                201,
+                { idmap: { animal: [[-1, 10]], person: [[-2, 100]] } },
+            ];
+        });
+
+        return animal.save({ relations: ['pastOwners'] }).then(() => {
+            expect(animal.pastOwners.map('id')).toEqual([100, 125]);
+        });
+    });
+
+    test('save all with validation errors', () => {
+        const animal = new Animal(
+            {
+                name: 'Doggo',
+                kind: { name: 'Dog' },
+                pastOwners: [{ name: 'Jo', town: { id: 5, name: '' } }],
+            },
+            { relations: ['kind', 'pastOwners.town'] }
+        );
+        mock.onAny().replyOnce(config => {
+            return [400, animalMultiPutError];
+        });
+
+        return animal.save({ relations: ['kind'] }).then(
+            () => {},
+            err => {
+                if (!err.response) {
+                    throw err;
+                }
+                expect(toJS(animal.backendValidationErrors).name).toEqual([
+                    'blank',
+                ]);
+                expect(toJS(animal.kind.backendValidationErrors).name).toEqual([
+                    'required',
+                ]);
+                expect(
+                    toJS(animal.pastOwners.at(0).backendValidationErrors).name
+                ).toEqual(['required']);
+                expect(
+                    toJS(animal.pastOwners.at(0).town.backendValidationErrors)
+                        .name
+                ).toEqual(['maxlength']);
+            }
+        );
+    });
+
+    test('save all with validation errors and check if it clears them', () => {
+        const animal = new Animal(
+            {
+                name: 'Doggo',
+                pastOwners: [{ name: 'Jo', town: { id: 5, name: '' } }],
+            },
+            { relations: ['pastOwners.town'] }
+        );
+
+        // We first trigger a save with validation errors from the backend, then we trigger a second save which fixes those validation errors,
+        // then we check if the errors get cleared.
+        mock.onAny().replyOnce(config => {
+            return [400, animalMultiPutError];
+        });
+
+        const options = { relations: ['pastOwners.town'] };
+        return animal.save(options).then(
+            () => {},
+            err => {
+                if (!err.response) {
+                    throw err;
+                }
+                mock.onAny().replyOnce(200, { idmap: [] });
+                return animal.save(options).then(() => {
+                    const valErrors1 = toJS(
+                        animal.pastOwners.at(0).backendValidationErrors
+                    );
+                    expect(valErrors1).toEqual({});
+                    const valErrors2 = toJS(
+                        animal.pastOwners.at(0).town.backendValidationErrors
+                    );
+                    expect(valErrors2).toEqual({});
+                });
+            }
+        );
+    });
+
+    test('save all with existing model', () => {
+        const animal = new Animal(
+            { id: 10, name: 'Doggo', kind: { name: 'Dog' } },
+            { relations: ['kind'] }
+        );
+        mock.onAny().replyOnce(config => {
+            expect(config.url).toBe('/api/animal/');
+            expect(config.method).toBe('put');
+            const putData = JSON.parse(config.data);
+            expect(putData).toMatchSnapshot();
+            return [201, animalMultiPutResponse];
+        });
+
+        return animal.save({ relations: ['kind'] });
+    });
+
+    test('hasUserChanges should clear changes in saved model relations', () => {
+        const animal = new Animal({ id: 1 }, { relations: ['kind.breed'] });
+
+        animal.kind.breed.setInput('name', 'Katachtige');
+
+        mock.onAny().replyOnce(() => {
+            return [200, {}];
+        });
+
+        return animal.save({ relations: ['kind.breed'] }).then(() => {
+            expect(animal.hasUserChanges).toBe(false);
+        });
+    });
+
+    test('hasUserChanges should not clear changes in non-saved models relations', () => {
+        const animal = new Animal(
+            { id: 1, pastOwners: [
+                { id: 2 },
+                { id: 3 },
+            ] },
+            { relations: ['pastOwners', 'kind.breed'] }
+        );
+
+        animal.kind.breed.setInput('name', 'Katachtige');
+        animal.pastOwners.get(2).setInput('name', 'Zaico');
+
+        mock.onAny().replyOnce(() => {
+            return [200, {}];
+        });
+
+        return animal.save({ relations: ['kind.breed'] }).then(() => {
+            expect(animal.hasUserChanges).toBe(true);
+            expect(animal.pastOwners.hasUserChanges).toBe(true);
+            expect(animal.pastOwners.get(2).hasUserChanges).toBe(true);
+            expect(animal.pastOwners.get(3).hasUserChanges).toBe(false);
+        });
+    });
+
+    test('hasUserChanges should clear set changes in saved relations', () => {
+        const animal = new Animal(
+            { id: 1, pastOwners: [
+                { id: 2 },
+                { id: 3 },
+            ] },
+            { relations: ['pastOwners', 'kind.breed'] }
+        );
+
+        animal.pastOwners.add({});
+        expect(animal.hasUserChanges).toBe(true);
+        expect(animal.pastOwners.hasUserChanges).toBe(true);
+
+        mock.onAny().replyOnce(() => {
+            return [200, {}];
+        });
+
+        return animal.save({ relations: ['pastOwners'] }).then(() => {
+            expect(animal.pastOwners.hasUserChanges).toBe(false);
+            expect(animal.hasUserChanges).toBe(false);
         });
     });
 });

--- a/src/__tests__/__snapshots__/Model.js.snap
+++ b/src/__tests__/__snapshots__/Model.js.snap
@@ -20,26 +20,6 @@ Object {
 }
 `;
 
-exports[`requests save all with existing model 2`] = `
-Object {
-  "data": Array [
-    Object {
-      "id": 10,
-      "kind": -2,
-      "name": "Doggo",
-    },
-  ],
-  "with": Object {
-    "kind": Array [
-      Object {
-        "id": -2,
-        "name": "Dog",
-      },
-    ],
-  },
-}
-`;
-
 exports[`toBackendAll should de-duplicate relations 1`] = `
 Object {
   "data": Array [

--- a/src/__tests__/__snapshots__/Model.js.snap
+++ b/src/__tests__/__snapshots__/Model.js.snap
@@ -20,6 +20,26 @@ Object {
 }
 `;
 
+exports[`requests save all with existing model 2`] = `
+Object {
+  "data": Array [
+    Object {
+      "id": 10,
+      "kind": -2,
+      "name": "Doggo",
+    },
+  ],
+  "with": Object {
+    "kind": Array [
+      Object {
+        "id": -2,
+        "name": "Dog",
+      },
+    ],
+  },
+}
+`;
+
 exports[`toBackendAll should de-duplicate relations 1`] = `
 Object {
   "data": Array [


### PR DESCRIPTION
There is now one `save` method that behaves like the old `saveAll` when you supply relations and works like the old save when you don't.