### PR TITLE
Debounce fetch for going up or down a page

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -335,7 +335,7 @@ export default class Store {
     getNextPage() {
         invariant(this.hasNextPage, 'There is no next page.');
         this.__state.currentPage += 1;
-        debouncedFetch = debounce(this.fetch, 300)
+        const debouncedFetch = debounce(this.fetch, 300)
         return debouncedFetch();
     }
 
@@ -343,7 +343,7 @@ export default class Store {
     getPreviousPage() {
         invariant(this.hasPreviousPage, 'There is no previous page.');
         this.__state.currentPage -= 1;
-        debouncedFetch = debounce(this.fetch, 300)
+        const debouncedFetch = debounce(this.fetch, 300)
         return debouncedFetch();
     }
 


### PR DESCRIPTION
Should fix issues:
` When clicking the right arrow multiple times to go to the last page, it seems that all intermittent pages are also loaded in the background and slows down the process of going to the last page.`
and
`Using the right arrow button to navigate to the last page, results in the last to one page is shown. Example: when navigating to page 4 (when there are 4 pages), page 4 seems to be loaded briefly, and then page 3 is shown. The url still indicates that we're viewing page 4 as does the page navigation, except the content of page 3 is shown. It is most notable for pages that don't load quickly like Tracy at the moment.`
from [T31853](https://phabricator.codeyellow.nl/T31853)
